### PR TITLE
[MOB-824] fix: copy metadata in HLS from initialization fragment

### DIFF
--- a/libavformat/hls.c
+++ b/libavformat/hls.c
@@ -1713,6 +1713,20 @@ static int set_stream_info_from_input_stream(AVStream *st, struct playlist *pls,
     else
         avpriv_set_pts_info(st, ist->pts_wrap_bits, ist->time_base.num, ist->time_base.den);
 
+    // copy disposition
+    st->disposition = ist->disposition;
+
+    // copy side data
+    for (int i = 0; i < ist->nb_side_data; i++) {
+        const AVPacketSideData *sd_src = &ist->side_data[i];
+        uint8_t *dst_data;
+
+        dst_data = av_stream_new_side_data(st, sd_src->type, sd_src->size);
+        if (!dst_data)
+            return AVERROR(ENOMEM);
+        memcpy(dst_data, sd_src->data, sd_src->size);
+    }
+
     st->internal->need_context_update = 1;
 
     return 0;


### PR DESCRIPTION
Cherry picking https://github.com/FFmpeg/FFmpeg/commit/b7f3a7c439885945af697580a0c08c0573f8885b# 

https://www.loom.com/share/224f49591a3a44a580a6b28264e9b608