### PR TITLE
lavf/hls: Add missed side data/disposition

### DIFF
--- a/libavformat/hls.c
+++ b/libavformat/hls.c
@@ -1768,6 +1768,20 @@ static int set_stream_info_from_input_stream(AVStream *st, struct playlist *pls,
     else
         avpriv_set_pts_info(st, ist->pts_wrap_bits, ist->time_base.num, ist->time_base.den);
 
+    // copy disposition
+    st->disposition = ist->disposition;
+
+    // copy side data
+    for (int i = 0; i < ist->nb_side_data; i++) {
+        const AVPacketSideData *sd_src = &ist->side_data[i];
+        uint8_t *dst_data;
+
+        dst_data = av_stream_new_side_data(st, sd_src->type, sd_src->size);
+        if (!dst_data)
+            return AVERROR(ENOMEM);
+        memcpy(dst_data, sd_src->data, sd_src->size);
+    }
+
     st->internal->need_context_update = 1;
 
     return 0;


### PR DESCRIPTION
Cherry pick from [b7f3a7c439885945af697580a0c08c0573f8885b](https://github.com/FFmpeg/FFmpeg/commit/b7f3a7c439885945af697580a0c08c0573f8885b)

Original comment:
hls demuxer get the stream info from sub-stream, but missed side
data/disposition part, e,g, missed the DOVI side data when the
stream is Dolby Vision streams.

My comment:
We need to upgrade to 4.3.x, so we need to apply the same patch as we did for 4.0