### PR TITLE
fix: more chances to find a start code

### DIFF
--- a/libavformat/mpegtsenc.c
+++ b/libavformat/mpegtsenc.c
@@ -1551,9 +1551,24 @@ static void mpegts_write_pes(AVFormatContext *s, AVStream *st,
     ts_st->prev_payload_key = key;
 }
 
+static int is_h264_start_code_3bytes(const uint8_t* p) 
+{
+    if (p[0] == 0x0 && p[1] == 0x00 && p[2] == 0x01) return 1;
+    return 0;
+}
+
+static int can_find_h264_start_code(const uint8_t* p, size_t size) 
+{
+    for (int i = 0; i <= (size - 3); i++) {
+        int found = is_h264_start_code_3bytes(p + i);
+        if (found) return 1;
+    }
+    return 0;
+}
+
 int ff_check_h264_startcode(AVFormatContext *s, const AVStream *st, const AVPacket *pkt)
 {
-    if (pkt->size < 5 || AV_RB32(pkt->data) != 0x0000001 && AV_RB24(pkt->data) != 0x000001) {
+    if (pkt->size < 5 || !can_find_h264_start_code(pkt->data, FFMIN(pkt->size, 10))) {
         if (!st->nb_frames) {
             av_log(s, AV_LOG_ERROR, "H.264 bitstream malformed, "
                    "no startcode found, use the video bitstream filter 'h264_mp4toannexb' to fix it "


### PR DESCRIPTION
We explore a little deeper the stream in order to find the h264 start code. We know it's out there, somewhere

Faulty files will still fail

With this patch, old videos will still work. We can still patch our tsmuxer, though, although I think what we are producing it's ok

https://www.loom.com/share/feff5ae378c84fb7ac1b9b79df7abc63