### PR TITLE
fix: incrementing the number of complex filter to 200

### DIFF
--- a/libavutil/eval.c
+++ b/libavutil/eval.c
@@ -703,7 +703,7 @@ int av_expr_parse(AVExpr **expr, const char *s,
     *wp++ = 0;
 
     p.class      = &eval_class;
-    p.stack_index=100;
+    p.stack_index=200;
     p.s= w;
     p.const_names = const_names;
     p.funcs1      = funcs1;


### PR DESCRIPTION
This change increases the number of complex filters that ffmpeg can take. Currently, if someone has more than 100 trim ranges, ffmpeg will complain