### PR TITLE
MINT-4568 removing correcting start time code

### DIFF
--- a/fftools/ffmpeg.c
+++ b/fftools/ffmpeg.c
@@ -4454,24 +4454,24 @@ static int process_input(int file_index)
 
     if(!ist->wrap_correction_done && is->start_time != AV_NOPTS_VALUE && ist->st->pts_wrap_bits < 64){
         int64_t stime, stime2;
-        // Correcting starttime based on the enabled streams
-        // FIXME this ideally should be done before the first use of starttime but we do not know which are the enabled streams at that point.
-        //       so we instead do it here as part of discontinuity handling
-        if (   ist->next_dts == AV_NOPTS_VALUE
-            && ifile->ts_offset == -is->start_time
-            && (is->iformat->flags & AVFMT_TS_DISCONT)) {
-            int64_t new_start_time = INT64_MAX;
-            for (i=0; i<is->nb_streams; i++) {
-                AVStream *st = is->streams[i];
-                if(st->discard == AVDISCARD_ALL || st->start_time == AV_NOPTS_VALUE)
-                    continue;
-                new_start_time = FFMIN(new_start_time, av_rescale_q(st->start_time, st->time_base, AV_TIME_BASE_Q));
-            }
-            if (new_start_time > is->start_time) {
-                av_log(is, AV_LOG_VERBOSE, "Correcting start time by %"PRId64"\n", new_start_time - is->start_time);
-                ifile->ts_offset = -new_start_time;
-            }
-        }
+        // // Correcting starttime based on the enabled streams
+        // // FIXME this ideally should be done before the first use of starttime but we do not know which are the enabled streams at that point.
+        // //       so we instead do it here as part of discontinuity handling
+        // if (   ist->next_dts == AV_NOPTS_VALUE
+        //     && ifile->ts_offset == -is->start_time
+        //     && (is->iformat->flags & AVFMT_TS_DISCONT)) {
+        //     int64_t new_start_time = INT64_MAX;
+        //     for (i=0; i<is->nb_streams; i++) {
+        //         AVStream *st = is->streams[i];
+        //         if(st->discard == AVDISCARD_ALL || st->start_time == AV_NOPTS_VALUE)
+        //             continue;
+        //         new_start_time = FFMIN(new_start_time, av_rescale_q(st->start_time, st->time_base, AV_TIME_BASE_Q));
+        //     }
+        //     if (new_start_time > is->start_time) {
+        //         av_log(is, AV_LOG_VERBOSE, "Correcting start time by %"PRId64"\n", new_start_time - is->start_time);
+        //         ifile->ts_offset = -new_start_time;
+        //     }
+        // }
 
         stime = av_rescale_q(is->start_time, AV_TIME_BASE_Q, ist->st->time_base);
         stime2= stime + (1ULL<<ist->st->pts_wrap_bits);


### PR DESCRIPTION
This PR removes some auto correcting timestamp that is affecting loom videos.

The videos affected are ts files with audio and video, where video starts at 0, and audio starts at T, and we ask ffmpeg to remove the video track and just leave the audio track. The auto correcting code will make all audio pts start at 0, applying an offset of -T

This is the original commit: https://github.com/FFmpeg/FFmpeg/commit/d92073ac9346027de42fda9d934e47f5a2bc97e1

https://www.loom.com/share/demo-of-ffmpeg-441-loom-patch-6-f51a8858c9254e1ab392864a8432ecf5