### PR TITLE
MINT-5063 increment number of complex filters

### DIFF
--- a/libavutil/eval.c
+++ b/libavutil/eval.c
@@ -729,7 +729,7 @@ int av_expr_parse(AVExpr **expr, const char *s,
     *wp++ = 0;
 
     p.class      = &eval_class;
-    p.stack_index=200;
+    p.stack_index=300;
     p.s= w;
     p.const_names = const_names;
     p.funcs1      = funcs1;


### PR DESCRIPTION
long videos with large number of trims are hitting ffmpeg args limit. 
https://linear.app/loom-com/issue/MINT-5063/ffmpeg-unable-to-process-commands-with-large-if-arguments