### PR TITLE
Increase FFmpeg filters to 500

### DIFF
--- a/libavutil/eval.c
+++ b/libavutil/eval.c
@@ -729,7 +729,7 @@ int av_expr_parse(AVExpr **expr, const char *s,
     *wp++ = 0;
 
     p.class      = &eval_class;
-    p.stack_index=500;
+    p.stack_index=700;
     p.s= w;
     p.const_names = const_names;
     p.funcs1      = funcs1;

--- a/libavutil/eval.c
+++ b/libavutil/eval.c
@@ -729,7 +729,7 @@ int av_expr_parse(AVExpr **expr, const char *s,
     *wp++ = 0;
 
     p.class      = &eval_class;
-    p.stack_index=300;
+    p.stack_index=500;
     p.s= w;
     p.const_names = const_names;
     p.funcs1      = funcs1;


### PR DESCRIPTION
We're [encountering media](https://app.datadoghq.com/logs?query=%40video_id%3A24923328c6f34d4ba488112235eaa7da%20-status%3Ainfo&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZP-KkWleF5_GAAAABhBWlAtS2xkdEFBQnZmSFlTY1BVQ09RQUEAAAAkMDE5M2ZlMmItOTM2MC00YzhmLTg2NDQtZDM2ZTkwN2I3MTJiAAG9nA&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1733685588705&to_ts=1736277588705&live=true) with number of trims over 300. This is causing FFmpeg to fail. Increasing this to 500.