### PR TITLE
MINT - Enable timeline editing for overlay_cuda

### DIFF
--- a/libavfilter/vf_overlay_cuda.c
+++ b/libavfilter/vf_overlay_cuda.c
@@ -588,5 +588,6 @@ const AVFilter ff_vf_overlay_cuda = {
     FILTER_OUTPUTS(overlay_cuda_outputs),
     FILTER_SINGLE_PIXFMT(AV_PIX_FMT_CUDA),
     .preinit         = overlay_cuda_framesync_preinit,
+    .flags          = AVFILTER_FLAG_SUPPORT_TIMELINE_INTERNAL,
     .flags_internal  = FF_FILTER_FLAG_HWFRAME_AWARE,
 };


### PR DESCRIPTION
The existing overlay filter allows [timeline editing](https://ffmpeg.org/ffmpeg-filters.html#Timeline-editing) through the `enable` option which we make use of. Enabling this for the `overlay_cuda` filter.

Other cuda filters already have this enabled in the same way: [bwdif_cuda](https://github.com/loomhq/FFmpeg/blob/n7.0.1.loom-patch3/libavfilter/vf_bwdif_cuda.c#L366) and [yadif_cuda](https://github.com/loomhq/FFmpeg/blob/n7.0.1.loom-patch3/libavfilter/vf_yadif_cuda.c#L352)