### PR TITLE
MINT - Patch NVDEC to limit decode surfaces

### DIFF
--- a/libavcodec/nvdec.c
+++ b/libavcodec/nvdec.c
@@ -222,6 +222,12 @@ static int nvdec_decoder_create(NVDECDecoder **out, AVBufferRef *hw_device_ref,
         goto fail;
     }
 
+    // Check and limit ulNumDecodeSurfaces
+    if (params->ulNumDecodeSurfaces > 32) {
+        av_log(logctx, AV_LOG_WARNING, "ulNumDecodeSurfaces (%lu) exceeds 32, limiting to 32.\n", params->ulNumDecodeSurfaces);
+        params->ulNumDecodeSurfaces = 32;
+    }
+
     ret = CHECK_CU(decoder->cvdl->cuvidCreateDecoder(&decoder->decoder, params));
 
     CHECK_CU(decoder->cudl->cuCtxPopCurrent(&dummy));


### PR DESCRIPTION
Tested on my personal PC and a decode surface value larger than 32 is not allowed for NVDEC and causes the decoder to fail to initialize. This isn't documented anywhere in [NVIDIAs NVDEC docs](https://docs.nvidia.com/video-technologies/video-codec-sdk/12.2/nvdec-video-decoder-api-prog-guide/index.html#creating-a-decoder) as far as I can tell.

This should fix the GPU failures we're seeing with some inputs.