### PR TITLE
MINT - Fix yuva420p to yuv420p conversion for scale_npp

### DIFF
--- a/libavfilter/vf_scale_npp.c
+++ b/libavfilter/vf_scale_npp.c
@@ -741,6 +741,15 @@ static int nppscale_resize(AVFilterContext *ctx, NPPScaleStageContext *stage,
         int ow = stage->planes_out[i].width;
         int oh = stage->planes_out[i].height;
 
+        // If the output plane pointer is NULL, or if the output plane has zero dimensions
+        // (which might happen if the output format has fewer planes than the input ie YUVA420P -> YUV420P),
+        // skip processing for this plane.
+        if (!out->data[i] || ow == 0 || oh == 0) {
+            av_log(ctx, AV_LOG_DEBUG, "Skipping plane %d (iw=%d, ih=%d -> ow=%d, oh=%d). Output data pointer: %p.\n",
+                   i, iw, ih, ow, oh, out->data[i]);
+            continue; 
+        }
+
         err = nppiResizeSqrPixel_8u_C1R(in->data[i], (NppiSize){ iw, ih },
                                         in->linesize[i], (NppiRect){ 0, 0, iw, ih },
                                         out->data[i], out->linesize[i],


### PR DESCRIPTION
When `scale_npp` converts from yuva420p to yuv420p it creates 3 output planes. However, it runs the resize action on all planes on the input. If we had 4 planes on the input and 3 on the output the resize action fails since there is no output plane to write to. This adds a check to determine if there is an output plane available for the resized output otherwise we skip and discard the unused plane, in this case the alpha plane.