### PR TITLE
MINT - Fix internal.h import

### DIFF
--- a/libavfilter/vf_alphamerge_cuda.c
+++ b/libavfilter/vf_alphamerge_cuda.c
@@ -23,6 +23,7 @@
  * Copy the luma value of the second input into the alpha channel of the first input using CUDA.
  */
 
+#include "libavutil/internal.h"
 #include "libavutil/opt.h"
 #include "libavutil/pixdesc.h"
 #include "libavutil/hwcontext.h"
@@ -34,7 +35,6 @@
 #include "filters.h"
 #include "formats.h"
 #include "framesync.h"
-#include "internal.h"
 #include "video.h"
 
 #include "cuda/load_helper.h"

--- a/libavfilter/vf_crop_npp.c
+++ b/libavfilter/vf_crop_npp.c
@@ -27,7 +27,7 @@
 #include <nppi.h>
 
 #include "filters.h"
-#include "internal.h"
+#include "libavutil/internal.h"
 #include "libavutil/avstring.h"
 #include "libavutil/common.h"
 #include "libavutil/cuda_check.h"


### PR DESCRIPTION
On the FFmpeg version I have on my personal PC importing "internal.h" is correct. On our build of FFmpeg we need to import "libavutil/internal.h". At a glance the rest of the imports look correct