### PR TITLE
MINT - Fix double free in alphamerge_cuda

### DIFF
--- a/libavfilter/vf_alphamerge_cuda.c
+++ b/libavfilter/vf_alphamerge_cuda.c
@@ -202,7 +202,6 @@ static int do_alphamerge_cuda(FFFrameSync *fs)
     if (ret < 0) {
         av_log(ctx, AV_LOG_ERROR, "failed to get push CUDA context\n");
         av_frame_free(&main_frame);
-        av_frame_free(&alpha_mask_frame);
         return ret;
     }
 
@@ -242,7 +241,6 @@ static int do_alphamerge_cuda(FFFrameSync *fs)
         av_log(avctx, AV_LOG_ERROR, "Failed to launch CUDA kernel\n");
         CHECK_CU(cu->cuCtxPopCurrent(&dummy_cu_ctx));
         av_frame_free(&main_frame);
-        av_frame_free(&alpha_mask_frame);
         return ret;
     }
 
@@ -251,12 +249,8 @@ static int do_alphamerge_cuda(FFFrameSync *fs)
     if (ret < 0) {
         av_log(avctx, AV_LOG_ERROR, "Failed to pop CUDA context\n");
         av_frame_free(&main_frame);
-        av_frame_free(&alpha_mask_frame);
         return ret;
     }
-
-    // alpha_mask_frame is not needed downstream so we can release it
-    av_frame_free(&alpha_mask_frame);
 
     return ff_filter_frame(outlink, main_frame);
 }


### PR DESCRIPTION
This was introduced as part of the feedback from when I first introduced `alphamerge_cuda`. I forgot that we should not be freeing `alpha_mask_input` since this frame is not 'writable' and is owned by the `FrameSync` object upstream. It will handle discarding the frame and calling free on the frame results in a double free. The only frame we own is the `main_frame` which is returned as writable and should be either passed onto the next filter or freed on failure.