### PR TITLE
Patch 6 - Fix the aselect filter

### DIFF
--- a/libavfilter/f_select.c
+++ b/libavfilter/f_select.c
@@ -504,6 +504,7 @@ const FFFilter ff_af_aselect = {
     .p.flags       = AVFILTER_FLAG_DYNAMIC_OUTPUTS,
     .init        = aselect_init,
     .uninit      = uninit,
+    .activate    = activate,
     .priv_size   = sizeof(SelectContext),
     FILTER_INPUTS(avfilter_af_aselect_inputs),
 };


### PR DESCRIPTION
Those funny guys at FFmpeg decided to pull a fast one on me and [completely broke the aselect filter](https://github.com/loomhq/FFmpeg/commit/af189e424b9272c804a79fbb2a2e4cfc7f199c0a) so that it does absolutely nothing. Don't worry this one simple line should do the trick.


I used @ncooleyy 's repro of the issue to test this fix.

This is the FFmpeg 7.1 generated segment
[7-out1.ts](https://github.com/user-attachments/files/23420581/7-out1.ts)

This is the FFmpeg 8 generated segment without the fix (audio overlapping and skipping)
[8-out1-broken.ts](https://github.com/user-attachments/files/23420583/8-out1-broken.ts)

This is the FFmpeg 8 output with this fix (matches the 7.1 output)
[8-out1-fixed.ts](https://github.com/user-attachments/files/23420584/8-out1-fixed.ts)

 


