### PR TITLE
n9.0.1 Patch 3: Use refcounting to avoid mem copy in alphamerge

### DIFF
--- a/libavfilter/vf_alphamerge.c
+++ b/libavfilter/vf_alphamerge.c
@@ -83,7 +83,7 @@ static int do_alphamerge(FFFrameSync *fs)
         AVBufferRef *alpha_plane_buf = av_frame_get_plane_buffer(alpha_buf, Y);
 
         if (!alpha_plane_buf) {
-            av_log(ctx, AV_LOG_ERROR, "Cloud not get buffer for alpha plane\n");
+            av_log(ctx, AV_LOG_ERROR, "Could not get buffer for alpha plane\n");
             return AVERROR(EINVAL);
         }
 

--- a/libavfilter/vf_alphamerge.c
+++ b/libavfilter/vf_alphamerge.c
@@ -28,12 +28,12 @@
 #include "libavutil/imgutils.h"
 #include "libavutil/opt.h"
 #include "libavutil/pixfmt.h"
+#include "libavutil/buffer.h"
 #include "avfilter.h"
 #include "drawutils.h"
 #include "formats.h"
 #include "filters.h"
 #include "framesync.h"
-#include "video.h"
 
 enum { Y, U, V, A };
 
@@ -80,11 +80,21 @@ static int do_alphamerge(FFFrameSync *fs)
             }
         }
     } else {
-        const int main_linesize = main_buf->linesize[A];
-        const int alpha_linesize = alpha_buf->linesize[Y];
-        av_image_copy_plane(main_buf->data[A], main_linesize,
-                            alpha_buf->data[Y], alpha_linesize,
-                            FFMIN(main_linesize, alpha_linesize), alpha_buf->height);
+        AVBufferRef *alpha_plane_buf = av_frame_get_plane_buffer(alpha_buf, Y);
+
+        if (!alpha_plane_buf) {
+            av_log(ctx, AV_LOG_ERROR, "Cloud not get buffer for alpha plane\n");
+            return AVERROR(EINVAL);
+        }
+
+        ret = av_buffer_replace(&main_buf->buf[A], alpha_plane_buf);
+        if (ret < 0) {
+            av_log(ctx, AV_LOG_ERROR, "Failed to replace alpha plane buffer.\n");
+            return ret;
+        }
+
+        main_buf->data[A] = alpha_buf->data[Y];
+        main_buf->linesize[A] = alpha_buf->linesize[Y];
     }
 
     return ff_filter_frame(ctx->outputs[0], main_buf);


### PR DESCRIPTION
Predecessor PR: [#31](https://github.com/loomhq/FFmpeg/pull/31).



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

