### PR TITLE
n9.0.1 Patch 5: Raise AVExpr MAX_DEPTH to 700

### DIFF
--- a/libavutil/eval.c
+++ b/libavutil/eval.c
@@ -41,7 +41,7 @@
 #include "avstring.h"
 #include "reverse.h"
 
-#define MAX_DEPTH 100
+#define MAX_DEPTH 700
 
 typedef struct Parser {
     const AVClass *class;


### PR DESCRIPTION
Similar to https://github.com/loomhq/FFmpeg/pull/36, this is necessary to allow for more than 100 trims. 

Cause of [this](https://github.com/loomhq/loom/actions/runs/31820190683/job/94831763170?pr=66942#step:9:69) test failure in CI



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

