### PR TITLE
n9.0.1 Patch 6: Stop DASH demuxing at first component EOF

### DIFF
--- a/libavformat/dashdec.c
+++ b/libavformat/dashdec.c
@@ -2383,7 +2383,7 @@ static int dash_read_packet(AVFormatContext *s, AVPacket *pkt)
     }
 
     if (!cur) {
-        return AVERROR_EOF;
+        return AVERROR_INVALIDDATA;
     }
     while (!ff_check_interrupt(c->interrupt_callback) && !ret) {
         ret = av_read_frame(cur->ctx, pkt);
@@ -2399,17 +2399,9 @@ static int dash_read_packet(AVFormatContext *s, AVPacket *pkt)
             cur->is_restart_needed = 0;
             ff_format_io_close(cur->parent, &cur->input);
             ret = reopen_demux_for_component(s, cur);
-        } else if (ret == AVERROR_EOF) {
-            close_demux_for_component(cur);
-            ff_format_io_close(cur->parent, &cur->input);
-            av_log(s, AV_LOG_DEBUG, "EOF on stream_index %d\n", cur->stream_index);
-            // prevent recheck_discard_flags() from re-enabling the component
-            for (int i = 0; i < cur->nb_assoc_stream; i++)
-                cur->assoc_stream[i]->discard = AVDISCARD_ALL;
-            return FFERROR_REDO;
         }
     }
-    return ret;
+    return AVERROR_EOF;
 }
 
 static int dash_close(AVFormatContext *s)


### PR DESCRIPTION
Reverts upstream [a5ef0da32a](https://git.ffmpeg.org/gitweb/ffmpeg.git/blobdiff/95fe88589a7254a8b88e76ae4eae2fe0359dc11d..a5ef0da32a:/libavformat/dashdec.c) ("avformat/dashdec: don't stop at the first input
EOF") in `libavformat/dashdec.c`, restoring 8.0's behaviour of ending demuxing
when the first Representation hits EOF.

### Why

9.0.1 keeps reading other Representations after one ends. For V5 DASH with
unequal stream extents this lengthens output: `large-time-gap.mpd` declares
`mediaPresentationDuration="PT6.0S"` but its video timeline runs 3014→9014ms, so
the container went 6.0s → 9.0s (5s → 8s after trim). Users get a video longer
than they recorded.

<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

